### PR TITLE
feat: add WP-Cron reconciliation job for pending payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- WP-Cron reconciliation job that polls the Stancer API every 15 minutes for
+  payments still recorded as "pending" locally, and updates WooCommerce order
+  statuses accordingly (complete for captured/to_capture, failed for
+  refused/failed/canceled/expired). Stancer does not support webhooks, so this
+  job is required to ensure orders are not left permanently in a pending state.
+
+
 ## [1.4.0] - 2025-08-01
 
 ### Added

--- a/includes/class-stancer-cron.php
+++ b/includes/class-stancer-cron.php
@@ -24,7 +24,7 @@ use Stancer;
  *
  * Schedule / unschedule are called on plugin activation / deactivation.
  *
- * @since 1.4.0
+ * @since Unreleased
  *
  * @package stancer
  * @subpackage stancer/includes
@@ -34,7 +34,7 @@ class WC_Stancer_Cron {
 	/**
 	 * WP-Cron hook name.
 	 *
-	 * @since 1.4.0
+	 * @since Unreleased
 	 *
 	 * @var string
 	 */
@@ -43,7 +43,7 @@ class WC_Stancer_Cron {
 	/**
 	 * Custom cron schedule identifier.
 	 *
-	 * @since 1.4.0
+	 * @since Unreleased
 	 *
 	 * @var string
 	 */
@@ -55,7 +55,7 @@ class WC_Stancer_Cron {
 	 * Payments younger than this threshold are skipped to allow the Stancer
 	 * payment page to complete its redirect flow before we poll the API.
 	 *
-	 * @since 1.4.0
+	 * @since Unreleased
 	 *
 	 * @var int
 	 */
@@ -66,7 +66,7 @@ class WC_Stancer_Cron {
 	 *
 	 * Hooked to the WordPress `cron_schedules` filter.
 	 *
-	 * @since 1.4.0
+	 * @since Unreleased
 	 *
 	 * @param array<string, array<string, mixed>> $schedules Existing cron schedules.
 	 *
@@ -86,7 +86,7 @@ class WC_Stancer_Cron {
 	 *
 	 * Called on plugin activation. Has no effect if already scheduled.
 	 *
-	 * @since 1.4.0
+	 * @since Unreleased
 	 *
 	 * @return void
 	 */
@@ -101,7 +101,7 @@ class WC_Stancer_Cron {
 	 *
 	 * Called on plugin deactivation.
 	 *
-	 * @since 1.4.0
+	 * @since Unreleased
 	 *
 	 * @return void
 	 */
@@ -116,26 +116,34 @@ class WC_Stancer_Cron {
 	/**
 	 * Reconcile pending payments by polling the Stancer API.
 	 *
-	 * Finds all local payments with status "pending" that were created more
-	 * than THRESHOLD seconds ago and checks their real status against the API.
-	 * Updates the local record and the WooCommerce order accordingly.
+	 * Finds all local payments with status "pending" or "authorized" that were
+	 * created between THRESHOLD seconds ago and one week ago, then checks their
+	 * real status against the API. Updates the local record and the WooCommerce
+	 * order accordingly.
 	 *
-	 * @since 1.4.0
+	 * @since Unreleased
 	 *
 	 * @return void
 	 */
 	public function reconcile(): void {
 		global $wpdb;
 
-		$threshold = gmdate( 'Y-m-d H:i:s', time() - static::THRESHOLD );
+		$week_timestamp = 604800;
+
+		$minimum_threshold = gmdate( 'Y-m-d H:i:s', time() - static::THRESHOLD );
+		$maximum_threshold = gmdate( 'Y-m-d H:i:s', time() - $week_timestamp );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT * FROM {$wpdb->prefix}wc_stancer_payment
-				 WHERE status = 'pending'
-				 AND datetime_created <= %s",
-				$threshold
+				 WHERE `status` in ('pending','authorized')
+				 AND `datetime_created` <= %s
+				 AND `datetime_created` >= %s",
+				[
+					$minimum_threshold,
+					$maximum_threshold,
+				]
 			)
 		);
 		// phpcs:enable
@@ -146,8 +154,16 @@ class WC_Stancer_Cron {
 
 		$logger = wc_get_logger();
 
-		foreach ( $rows as $row ) {
-			$this->process_row( $row, $logger );
+		$config = ( new WC_Stancer_Gateway() )->api_config;
+		if ( $config->is_configured() ) {
+			foreach ( $rows as $row ) {
+				$this->process_row( $row, $logger );
+			}
+		} else {
+			$logger->info(
+				sprintf( 'Stancer cron: Stancer configuration is not properly set up, please check your setting page.' ),
+				[ 'source' => 'stancer-cron' ]
+			);
 		}
 	}
 
@@ -157,7 +173,7 @@ class WC_Stancer_Cron {
 	 * Retrieves the payment status from the Stancer API and updates the local
 	 * record and WooCommerce order if the status has changed.
 	 *
-	 * @since 1.4.0
+	 * @since Unreleased
 	 *
 	 * @param object              $row    Database row from wc_stancer_payment.
 	 * @param WC_Logger_Interface $logger WooCommerce logger.
@@ -169,29 +185,23 @@ class WC_Stancer_Cron {
 		$context    = [ 'source' => 'stancer-cron' ];
 
 		try {
-			$api_payment    = new Stancer\Payment( $payment_id );
-			$api_status_raw = $api_payment->status;
+			$api_payment = new Stancer\Payment( $payment_id );
+			$api_status  = $api_payment->status;
 
 			// No status yet — wait for next run.
-			if ( ! $api_status_raw ) {
+			if ( ! $api_status ) {
 				return;
 			}
 
-			// Normalize to string — compatible whether the SDK returns an enum
-			// (Stancer\Payment\Status, PHP 8.1+) or a plain string.
-			$api_status = $api_status_raw instanceof Stancer\Payment\Status
-				? $api_status_raw->value
-				: (string) $api_status_raw;
-
-			// Still pending on the API side — wait for next run.
-			if ( 'pending' === $api_status ) {
+			// Still authorized on the API side — wait for next run.
+			if ( Stancer\Payment\Status::AUTHORIZED === $api_status ) {
 				return;
 			}
 
 			// Update local record with the real API status.
 			$stancer_payment = new WC_Stancer_Payment();
 			$stancer_payment->hydrate( (array) $row );
-			$stancer_payment->mark_as( $api_status );
+			$stancer_payment->mark_as( $api_status->value );
 
 			// Retrieve the associated WooCommerce order.
 			$order = wc_get_order( (int) $row->order_id );
@@ -210,10 +220,10 @@ class WC_Stancer_Cron {
 			}
 
 			switch ( $api_status ) {
-				case Stancer\Payment\Status::TO_CAPTURE->value:
-				case Stancer\Payment\Status::CAPTURE->value:
-				case Stancer\Payment\Status::CAPTURE_SENT->value:
-				case Stancer\Payment\Status::CAPTURED->value:
+				case Stancer\Payment\Status::TO_CAPTURE:
+				case Stancer\Payment\Status::CAPTURE:
+				case Stancer\Payment\Status::CAPTURE_SENT:
+				case Stancer\Payment\Status::CAPTURED:
 					if ( $order->needs_payment() ) {
 						$order->payment_complete( $payment_id );
 						$order->add_order_note(
@@ -228,24 +238,23 @@ class WC_Stancer_Cron {
 								'Stancer cron: order %d marked complete (payment %s, status %s).',
 								$order->get_id(),
 								$payment_id,
-								$api_status
+								$api_status->value
 							),
 							$context
 						);
 					}
 					break;
 
-				case Stancer\Payment\Status::REFUSED->value:
-				case Stancer\Payment\Status::FAILED->value:
-				case Stancer\Payment\Status::CANCELED->value:
-				case Stancer\Payment\Status::EXPIRED->value:
+				case Stancer\Payment\Status::REFUSED:
+				case Stancer\Payment\Status::CANCELED:
+				case Stancer\Payment\Status::EXPIRED:
 					if ( ! $order->has_status( [ 'failed', 'cancelled' ] ) ) {
 						$order->update_status(
 							'failed',
 							sprintf(
 								// translators: "%1$s": Stancer payment status. "%2$s": Stancer payment identifier.
 								__( 'Payment %1$s via Stancer (Transaction ID: %2$s)', 'stancer' ),
-								$api_status,
+								$api_status->value,
 								$payment_id
 							)
 						);
@@ -254,7 +263,7 @@ class WC_Stancer_Cron {
 								'Stancer cron: order %d marked failed (payment %s, status %s).',
 								$order->get_id(),
 								$payment_id,
-								$api_status
+								$api_status->value
 							),
 							$context
 						);
@@ -266,7 +275,7 @@ class WC_Stancer_Cron {
 						sprintf(
 							'Stancer cron: payment %s has status "%s" — no action taken.',
 							$payment_id,
-							$api_status
+							$api_status->value
 						),
 						$context
 					);

--- a/includes/class-stancer-cron.php
+++ b/includes/class-stancer-cron.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * This file is a part of Stancer WordPress module.
+ *
+ * See readme for more informations.
+ *
+ * @link https://www.stancer.com/
+ * @license MIT
+ * @copyright 2023-2025 Stancer / Iliad 78
+ *
+ * @package stancer
+ * @subpackage stancer/includes
+ */
+
+use Stancer;
+
+/**
+ * WP-Cron reconciliation job for pending Stancer payments.
+ *
+ * Stancer does not support webhooks. This class registers a scheduled task
+ * that runs every 15 minutes to poll the Stancer API for payments still
+ * recorded as "pending" locally and updates WooCommerce order statuses
+ * accordingly.
+ *
+ * Schedule / unschedule are called on plugin activation / deactivation.
+ *
+ * @since 1.4.0
+ *
+ * @package stancer
+ * @subpackage stancer/includes
+ */
+class WC_Stancer_Cron {
+
+	/**
+	 * WP-Cron hook name.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @var string
+	 */
+	const HOOK = 'stancer_reconcile_pending_payments';
+
+	/**
+	 * Custom cron schedule identifier.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @var string
+	 */
+	const SCHEDULE = 'stancer_fifteen_minutes';
+
+	/**
+	 * Minimum age of a pending payment before it is reconciled (seconds).
+	 *
+	 * Payments younger than this threshold are skipped to allow the Stancer
+	 * payment page to complete its redirect flow before we poll the API.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @var int
+	 */
+	const THRESHOLD = 900; // 15 minutes.
+
+	/**
+	 * Register the custom 15-minute cron schedule.
+	 *
+	 * Hooked to the WordPress `cron_schedules` filter.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param array<string, array<string, mixed>> $schedules Existing cron schedules.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public static function add_schedule( array $schedules ): array {
+		$schedules[ static::SCHEDULE ] = [
+			'interval' => static::THRESHOLD,
+			'display'  => __( 'Every 15 minutes (Stancer reconciliation)', 'stancer' ),
+		];
+
+		return $schedules;
+	}
+
+	/**
+	 * Schedule the reconciliation event.
+	 *
+	 * Called on plugin activation. Has no effect if already scheduled.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return void
+	 */
+	public static function schedule(): void {
+		if ( ! wp_next_scheduled( static::HOOK ) ) {
+			wp_schedule_event( time(), static::SCHEDULE, static::HOOK );
+		}
+	}
+
+	/**
+	 * Unschedule the reconciliation event.
+	 *
+	 * Called on plugin deactivation.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return void
+	 */
+	public static function unschedule(): void {
+		$timestamp = wp_next_scheduled( static::HOOK );
+
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, static::HOOK );
+		}
+	}
+
+	/**
+	 * Reconcile pending payments by polling the Stancer API.
+	 *
+	 * Finds all local payments with status "pending" that were created more
+	 * than THRESHOLD seconds ago and checks their real status against the API.
+	 * Updates the local record and the WooCommerce order accordingly.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return void
+	 */
+	public function reconcile(): void {
+		global $wpdb;
+
+		$threshold = gmdate( 'Y-m-d H:i:s', time() - static::THRESHOLD );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM {$wpdb->prefix}wc_stancer_payment
+				 WHERE status = 'pending'
+				 AND datetime_created <= %s",
+				$threshold
+			)
+		);
+		// phpcs:enable
+
+		if ( empty( $rows ) ) {
+			return;
+		}
+
+		$logger = wc_get_logger();
+
+		foreach ( $rows as $row ) {
+			$this->process_row( $row, $logger );
+		}
+	}
+
+	/**
+	 * Process a single pending payment row.
+	 *
+	 * Retrieves the payment status from the Stancer API and updates the local
+	 * record and WooCommerce order if the status has changed.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param object              $row    Database row from wc_stancer_payment.
+	 * @param WC_Logger_Interface $logger WooCommerce logger.
+	 *
+	 * @return void
+	 */
+	private function process_row( object $row, WC_Logger_Interface $logger ): void {
+		$payment_id = $row->payment_id;
+		$context    = [ 'source' => 'stancer-cron' ];
+
+		try {
+			$api_payment = new Stancer\Payment( $payment_id );
+			$api_status  = $api_payment->status;
+
+			// No status yet or still pending on the API side — wait for next run.
+			if ( ! $api_status ) {
+				return;
+			}
+
+			// Update local record with the real API status.
+			$stancer_payment = new WC_Stancer_Payment();
+			$stancer_payment->hydrate( (array) $row );
+			$stancer_payment->mark_as( $api_status );
+
+			// Retrieve the associated WooCommerce order.
+			$order = wc_get_order( (int) $row->order_id );
+
+			if ( ! $order ) {
+				$logger->warning(
+					sprintf(
+						'Stancer cron: order %d not found for payment %s.',
+						(int) $row->order_id,
+						$payment_id
+					),
+					$context
+				);
+
+				return;
+			}
+
+			switch ( $api_status ) {
+				case Stancer\Payment\Status::TO_CAPTURE:
+				case Stancer\Payment\Status::CAPTURE:
+				case Stancer\Payment\Status::CAPTURE_SENT:
+				case Stancer\Payment\Status::CAPTURED:
+					if ( $order->needs_payment() ) {
+						$order->payment_complete( $payment_id );
+						$order->add_order_note(
+							sprintf(
+								// translators: "%s": Stancer payment identifier.
+								__( 'Payment confirmed via Stancer reconciliation (Transaction ID: %s)', 'stancer' ),
+								$payment_id
+							)
+						);
+						$logger->info(
+							sprintf(
+								'Stancer cron: order %d marked complete (payment %s, status %s).',
+								$order->get_id(),
+								$payment_id,
+								$api_status->value
+							),
+							$context
+						);
+					}
+					break;
+
+				case Stancer\Payment\Status::REFUSED:
+				case Stancer\Payment\Status::FAILED:
+				case Stancer\Payment\Status::CANCELED:
+				case Stancer\Payment\Status::EXPIRED:
+					if ( ! $order->has_status( [ 'failed', 'cancelled' ] ) ) {
+						$order->update_status(
+							'failed',
+							sprintf(
+								// translators: "%1$s": Stancer payment status. "%2$s": Stancer payment identifier.
+								__( 'Payment %1$s via Stancer (Transaction ID: %2$s)', 'stancer' ),
+								$api_status->value,
+								$payment_id
+							)
+						);
+						$logger->info(
+							sprintf(
+								'Stancer cron: order %d marked failed (payment %s, status %s).',
+								$order->get_id(),
+								$payment_id,
+								$api_status->value
+							),
+							$context
+						);
+					}
+					break;
+
+				default:
+					$logger->debug(
+						sprintf(
+							'Stancer cron: payment %s has status "%s" — no action taken.',
+							$payment_id,
+							$api_status->value
+						),
+						$context
+					);
+					break;
+			}
+		} catch ( Exception $e ) {
+			$logger->error(
+				sprintf(
+					'Stancer cron error for payment %s: %s',
+					$payment_id,
+					$e->getMessage()
+				),
+				$context
+			);
+		}
+	}
+}

--- a/includes/class-stancer-cron.php
+++ b/includes/class-stancer-cron.php
@@ -169,11 +169,22 @@ class WC_Stancer_Cron {
 		$context    = [ 'source' => 'stancer-cron' ];
 
 		try {
-			$api_payment = new Stancer\Payment( $payment_id );
-			$api_status  = $api_payment->status;
+			$api_payment    = new Stancer\Payment( $payment_id );
+			$api_status_raw = $api_payment->status;
 
-			// No status yet or still pending on the API side — wait for next run.
-			if ( ! $api_status ) {
+			// No status yet — wait for next run.
+			if ( ! $api_status_raw ) {
+				return;
+			}
+
+			// Normalize to string — compatible whether the SDK returns an enum
+			// (Stancer\Payment\Status, PHP 8.1+) or a plain string.
+			$api_status = $api_status_raw instanceof Stancer\Payment\Status
+				? $api_status_raw->value
+				: (string) $api_status_raw;
+
+			// Still pending on the API side — wait for next run.
+			if ( 'pending' === $api_status ) {
 				return;
 			}
 
@@ -199,10 +210,10 @@ class WC_Stancer_Cron {
 			}
 
 			switch ( $api_status ) {
-				case Stancer\Payment\Status::TO_CAPTURE:
-				case Stancer\Payment\Status::CAPTURE:
-				case Stancer\Payment\Status::CAPTURE_SENT:
-				case Stancer\Payment\Status::CAPTURED:
+				case Stancer\Payment\Status::TO_CAPTURE->value:
+				case Stancer\Payment\Status::CAPTURE->value:
+				case Stancer\Payment\Status::CAPTURE_SENT->value:
+				case Stancer\Payment\Status::CAPTURED->value:
 					if ( $order->needs_payment() ) {
 						$order->payment_complete( $payment_id );
 						$order->add_order_note(
@@ -217,24 +228,24 @@ class WC_Stancer_Cron {
 								'Stancer cron: order %d marked complete (payment %s, status %s).',
 								$order->get_id(),
 								$payment_id,
-								$api_status->value
+								$api_status
 							),
 							$context
 						);
 					}
 					break;
 
-				case Stancer\Payment\Status::REFUSED:
-				case Stancer\Payment\Status::FAILED:
-				case Stancer\Payment\Status::CANCELED:
-				case Stancer\Payment\Status::EXPIRED:
+				case Stancer\Payment\Status::REFUSED->value:
+				case Stancer\Payment\Status::FAILED->value:
+				case Stancer\Payment\Status::CANCELED->value:
+				case Stancer\Payment\Status::EXPIRED->value:
 					if ( ! $order->has_status( [ 'failed', 'cancelled' ] ) ) {
 						$order->update_status(
 							'failed',
 							sprintf(
 								// translators: "%1$s": Stancer payment status. "%2$s": Stancer payment identifier.
 								__( 'Payment %1$s via Stancer (Transaction ID: %2$s)', 'stancer' ),
-								$api_status->value,
+								$api_status,
 								$payment_id
 							)
 						);
@@ -243,7 +254,7 @@ class WC_Stancer_Cron {
 								'Stancer cron: order %d marked failed (payment %s, status %s).',
 								$order->get_id(),
 								$payment_id,
-								$api_status->value
+								$api_status
 							),
 							$context
 						);
@@ -255,7 +266,7 @@ class WC_Stancer_Cron {
 						sprintf(
 							'Stancer cron: payment %s has status "%s" — no action taken.',
 							$payment_id,
-							$api_status->value
+							$api_status
 						),
 						$context
 					);

--- a/includes/class-stancer.php
+++ b/includes/class-stancer.php
@@ -177,6 +177,7 @@ class WC_Stancer {
 			}
 		);
 		add_action( 'admin_notices', [ $this, 'display_depreciation' ] );
+		add_action( WC_Stancer_Cron::HOOK, [ new WC_Stancer_Cron(), 'reconcile' ] );
 	}
 
 	/**
@@ -216,6 +217,7 @@ class WC_Stancer {
 	 */
 	private function load_filters() {
 		add_filter( 'woocommerce_payment_gateways', [ $this, 'add_gateway' ] );
+		add_filter( 'cron_schedules', [ 'WC_Stancer_Cron', 'add_schedule' ] );
 	}
 
 	/**

--- a/stancer.php
+++ b/stancer.php
@@ -34,6 +34,10 @@ define( 'STANCER_FILE', __FILE__ );
 define( 'STANCER_DIRECTORY_PATH', plugin_dir_path( STANCER_FILE ) );
 
 require_once STANCER_DIRECTORY_PATH . '/vendor/autoload.php';
+require_once STANCER_DIRECTORY_PATH . 'includes/class-stancer-cron.php';
+
+register_activation_hook( STANCER_FILE, [ 'WC_Stancer_Cron', 'schedule' ] );
+register_deactivation_hook( STANCER_FILE, [ 'WC_Stancer_Cron', 'unschedule' ] );
 
 add_action( 'plugins_loaded', 'load_translations' );
 

--- a/stancer.php
+++ b/stancer.php
@@ -34,7 +34,6 @@ define( 'STANCER_FILE', __FILE__ );
 define( 'STANCER_DIRECTORY_PATH', plugin_dir_path( STANCER_FILE ) );
 
 require_once STANCER_DIRECTORY_PATH . '/vendor/autoload.php';
-require_once STANCER_DIRECTORY_PATH . 'includes/class-stancer-cron.php';
 
 register_activation_hook( STANCER_FILE, [ 'WC_Stancer_Cron', 'schedule' ] );
 register_deactivation_hook( STANCER_FILE, [ 'WC_Stancer_Cron', 'unschedule' ] );


### PR DESCRIPTION
## Problem

Stancer does not support webhooks. When a customer completes payment on the Stancer hosted page and is redirected back, the `receipt_page()` handler updates the WooCommerce order status correctly. However, **if the redirect never happens** (browser closed, network error, session expired), the local payment record stays in `pending` status indefinitely and the WooCommerce order is never completed — even though the payment was captured by Stancer.

This affects any shop running in redirect (`pip`) mode and means orders can stay stuck in "Pending payment" forever without any operator intervention.

## Solution

Add a **WP-Cron job** that runs every 15 minutes and polls the Stancer API for all locally-pending payments older than 15 minutes, then updates the WooCommerce order accordingly.

## Implementation

### New file: `includes/class-stancer-cron.php`

Class `WC_Stancer_Cron` with:

- `add_schedule()` — registers a custom `stancer_fifteen_minutes` cron interval (15 min) via the `cron_schedules` filter
- `schedule()` / `unschedule()` — called on plugin activation / deactivation to register or clear the scheduled event
- `reconcile()` — queries `wc_stancer_payment` for rows with `status = pending` and `datetime_created <= NOW() - 15 min`, then calls `process_row()` for each
- `process_row()` — fetches the real payment status from the Stancer API, updates the local record via `mark_as()`, and updates the WooCommerce order:
  - `to_capture`, `capture`, `capture_sent`, `captured` → `$order->payment_complete()`
  - `refused`, `failed`, `canceled`, `expired` → `$order->update_status('failed')`
  - Other statuses → logged at debug level, no action

Status values from the API are normalized to `string` immediately after retrieval (compatible with both enum return — PHP 8.1+ SDK — and plain string return).

All operations are wrapped in a try/catch that logs errors to the WooCommerce logger under the `stancer-cron` source.

### Modified: `includes/class-stancer.php`

- `load_actions()`: registers the cron callback via `add_action( WC_Stancer_Cron::HOOK, ... )`
- `load_filters()`: registers the custom schedule via `add_filter( 'cron_schedules', ... )`

### Modified: `stancer.php`

- `require_once` of `class-stancer-cron.php` (needed before activation hook fires, before the composer classmap is active)
- `register_activation_hook` → `WC_Stancer_Cron::schedule()`
- `register_deactivation_hook` → `WC_Stancer_Cron::unschedule()`

## Notes

- The 15-minute threshold avoids interfering with in-progress redirect flows
- The job is idempotent: `payment_complete()` and `update_status()` are no-ops on already-finalized orders
- The `wc_stancer_payment` table is already populated on payment creation, so no schema changes are required
- All user-facing strings are wrapped in `__()` for i18n